### PR TITLE
Move `phpsploit` to `WebShell - PHP` category

### DIFF
--- a/pentest/persistence/webshell.md
+++ b/pentest/persistence/webshell.md
@@ -4,7 +4,6 @@ WebShell - generic
 
 * [BeichenDream/Godzilla - 哥斯拉](https://github.com/BeichenDream/Godzilla)
 * [GoSecure/php7-opcache-override - Security-related PHP7 OPcache abuse tools and demo - 不实用，容易影响人家业务](https://github.com/GoSecure/php7-opcache-override)
-* [nil0x42/phpsploit - Stealth post-exploitation framework](https://github.com/nil0x42/phpsploit)
 * [rebeyond/Behinder - “冰蝎”动态二进制加密网站管理客户端](https://github.com/rebeyond/Behinder)
   * [Skactor/behinder_source - 冰蝎的源码（Decompile & Fixed）](https://github.com/Skactor/behinder_source)
 * [xl7dev/WebShell - Webshell && Backdoor Collection](https://github.com/xl7dev/WebShell)
@@ -16,6 +15,7 @@ WebShell - generic
 
 WebShell - PHP
 
+* [nil0x42/phpsploit - Full-featured C2 framework which silently persists on webserver via evil PHP oneliner](https://github.com/nil0x42/phpsploit)
 * [AntSwordProject/ant_php_extension - PHP 扩展, 用于 PHP-FPM、FastCGI、LD_PRELOAD等模式下突破 disabled_functions](https://github.com/AntSwordProject/ant_php_extension)
 * [epinna/weevely3 - Weaponized web shell](https://github.com/epinna/weevely3)
 * [Arrexel/phpbash - A semi-interactive PHP shell compressed into a single file](https://github.com/Arrexel/phpbash)


### PR DESCRIPTION
Phpsploit is a php webshell rather than a generic webshell.
I also updated the description, as it's currently set on phpsploit project

Nice work ! I loved awesome-opensource-security :heart: